### PR TITLE
Restored Return and Frustration Distribution

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,42 +2,33 @@ name: CI
 
 on:
   push:
-    branches:
-      - vanilla
-      - vanilla-dev
-      - expansion
-      - expansion-dev
-  pull_request:
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: devkitpro/devkitarm
     env:
       GAME_VERSION: EMERALD
       GAME_REVISION: 0
       GAME_LANGUAGE: ENGLISH
       MODERN: 0
       COMPARE: 0
-      UNUSED_ERROR: 0
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@master
 
       - name: Checkout agbcc
-        uses: actions/checkout@v2
+        uses: actions/checkout@master
         with:
           path: agbcc
           repository: pret/agbcc
 
       - name: Install binutils
         run: |
-          sudo apt update
-          sudo apt install -y build-essential libpng-dev libelf-dev
-        # build-essential, git, and libpng-dev are already installed
+          sudo apt install -y gcc-arm-none-eabi binutils-arm-none-eabi libpng-dev libelf-dev
+        # build-essential and git are already installed
         # gcc-arm-none-eabi is only needed for the modern build
         # as an alternative to dkP
-
+        
       - name: Install Dependencies
         run: |
           ./init_deps.sh
@@ -48,36 +39,27 @@ jobs:
           ./install.sh ../
         working-directory: agbcc
 
-      #- name: Agbcc
-      #  env:
-      #    MODERN: 0
-      #    COMPARE: 0
-      #  run: make -j${nproc} -O all
-
-      - name: Build Debug
-        env:
-          MODERN: 1
-          COMPARE: 0
-          RELEASE: 0
-        run: make -j${nproc} -O all
-
-      - name: Build Release
+      - name: Modern
         env:
           MODERN: 1
           COMPARE: 0
           RELEASE: 1
         run: make -j${nproc} -O all
 
-      - name: Update Memory Stats
-        uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: Memory Stats
-          path: pokeemerald_memorystats.csv
-
-      - name: Test
-        env:
-          MODERN: 1
-          TEST: 1
-        run: |
-          make -j${nproc} -O pokeemerald-test.elf
-          make -j${nproc} check
+            name: emerogue
+            path: emerogue.gba
+            retention-days: 1
+  
+      - uses: actions/upload-artifact@v4
+        with:
+            name: emerogue_elf
+            path: emerogue.elf
+            retention-days: 1
+            
+      - uses: actions/upload-artifact@v4
+        with:
+            name: emerogue_map
+            path: emerogue.map
+            retention-days: 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Compile
 
 on: workflow_dispatch
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,6 @@
 name: CI
 
-on:
-  push:
+on: workflow_dispatch
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,9 @@ jobs:
           COMPARE: 0
           RELEASE: 1
         run: make -j${nproc} -O all
+        # change RELEASE to 0 to compile debug
 
+        # delete or comment out code below this point to prevent uploading to github if using workflow purely for testing.
       - uses: actions/upload-artifact@v4
         with:
             name: emerogue

--- a/data/maps/Rogue_Route_QuickMap0/scripts.pory
+++ b/data/maps/Rogue_Route_QuickMap0/scripts.pory
@@ -1,0 +1,7 @@
+mapscripts Rogue_Route_QuickMap0_MapScripts 
+{
+    MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE
+    [
+        VAR_TEMP_1, 0: Rogue_Common_TurnPlayerNorth
+    ]
+}

--- a/data/maps/Rogue_Route_QuickMap1/scripts.pory
+++ b/data/maps/Rogue_Route_QuickMap1/scripts.pory
@@ -1,0 +1,7 @@
+mapscripts Rogue_Route_QuickMap1_MapScripts 
+{
+    MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE
+    [
+        VAR_TEMP_1, 0: Rogue_Common_TurnPlayerNorth
+    ]
+}

--- a/data/maps/Rogue_Route_QuickMap2/scripts.pory
+++ b/data/maps/Rogue_Route_QuickMap2/scripts.pory
@@ -1,0 +1,7 @@
+mapscripts Rogue_Route_QuickMap2_MapScripts 
+{
+    MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE
+    [
+        VAR_TEMP_1, 0: Rogue_Common_TurnPlayerNorth
+    ]
+}

--- a/data/maps/Rogue_Route_QuickMap3/scripts.pory
+++ b/data/maps/Rogue_Route_QuickMap3/scripts.pory
@@ -1,0 +1,7 @@
+mapscripts Rogue_Route_QuickMap3_MapScripts 
+{
+    MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE
+    [
+        VAR_TEMP_1, 0: Rogue_Common_TurnPlayerNorth
+    ]
+}

--- a/data/maps/Rogue_Route_QuickMap4/scripts.pory
+++ b/data/maps/Rogue_Route_QuickMap4/scripts.pory
@@ -1,0 +1,7 @@
+mapscripts Rogue_Route_QuickMap4_MapScripts 
+{
+    MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE
+    [
+        VAR_TEMP_1, 0: Rogue_Common_TurnPlayerNorth
+    ]
+}

--- a/data/maps/Rogue_Route_QuickMap5/scripts.pory
+++ b/data/maps/Rogue_Route_QuickMap5/scripts.pory
@@ -1,0 +1,7 @@
+mapscripts Rogue_Route_QuickMap5_MapScripts 
+{
+    MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE
+    [
+        VAR_TEMP_1, 0: Rogue_Common_TurnPlayerNorth
+    ]
+}


### PR DESCRIPTION
Added return and frustration to the tutor pool of all pokemon that can be taught rest via TM (except pyukumuku).

## Description

Used a set of find and replace regex expressions to add return and frustration to pokemon that learn rest, and sorting them to the correct position in the tutor pool, as it is the order they appear in game.
This is done because the current return/frustration distribution can feel arbitrary as most pokemon only learn them if they appear in one of the rogue ai movesets,

## Regex Expressions

Exact regex expressions used, first line is the search, and the second line is the replacement.

Adding return to pokemon which learn rest:
Find:		` (\bsTutorMoves_SPECIES[\s\S][^;]*MOVE_REST,)`
Replace:	` \1\n\tMOVE_RETURN,`

Swapping the position of return and retaliate to ensure correct order:
Find:		`(MOVE_RETURN,)\n\t(MOVE_RETALIATE,)`
Replace:	`\2\n\t\1`

Removing duplicate entries:
Find:		`MOVE_RETURN,\n\tMOVE_RETURN,`
Replace:	`MOVE_RETURN,`

Adding frustration to pokemon which learn return (done after manually removing return from pyukumuku):
Find:		`(\bsTutorMoves_SPECIES[\s\S][^;]*MOVE_RETURN,)`
Replace:	`\1\n\tMOVE_FRUSTRATION`

Moving frustration to the correct location in the tutor pool:
Find:		`(\bsTutorMoves_SPECIES[\s\S][^;]+?(?=\n\tMOVE_F[S-Z]|\n\tMOVE_[G-Z]))([\s\S][^;]*)\n\tMOVE_FRUSTRATION,`
Replace:	`\1\n\tMOVE_FRUSTRATION,\2`

removing duplicate entries:
Find:		`MOVE_FRUSTRATION,\n\tMOVE_FRUSTRATION,`
Replace:	`MOVE_FRUSTRATION,`

## **Discord contact info**

lungafermata

Feel free to reach out with questions on anything including understanding/adapting the regex expressions.
I am Australian so be prepared for a delay depending on when you ask.